### PR TITLE
Fix for incorrect UUID incrementation <Edit: Accidentally commited more. Please see other PRs>

### DIFF
--- a/CrashLoyal/src/Building.cpp
+++ b/CrashLoyal/src/Building.cpp
@@ -33,7 +33,7 @@ int Building::attack(int dmg) {
 }
 
 std::shared_ptr<Point> Building::getPosition() {
-	return std::shared_ptr<Point>(&(this->pos));
+	return std::make_shared<Point>(this->pos);
 }
 
 float Building::GetSize() const {
@@ -42,8 +42,11 @@ float Building::GetSize() const {
 
 void Building::attackProcedure(double elapsedTime) {
 	if (this->lastAttackTime >= this->GetAttackTime()) {
-		this->target->attack(this->GetDamage());
-		this->lastAttackTime = 0; // lastAttackTime is incremented in the main update function
+		if (this->target != nullptr) {
+			//this->target->attack(this->GetDamage());
+			this->lastAttackTime = 0; // lastAttackTime is incremented in the main update function
+		}
+		
 		return;
 	}
 }

--- a/CrashLoyal/src/Building.h
+++ b/CrashLoyal/src/Building.h
@@ -44,7 +44,7 @@ public:
 
 	Building(Point p, BuildingType type) : Building(p.x, p.y, type) { }
 
-	bool isDead() { return this->health >= 0; }
+	bool isDead() { return this->health <= 0; }
 
 	int attack(int dmg);
 

--- a/CrashLoyal/src/Mob.cpp
+++ b/CrashLoyal/src/Mob.cpp
@@ -16,13 +16,14 @@ Mob::Mob()
 	, nextWaypoint(NULL)
 	, targetPosition(new Point)
 	, state(MobState::Moving)
-	, uuid(Mob::previousUUID)
+	, uuid(Mob::previousUUID + 1)
 	, attackingNorth(true)
 	, health(-1)
 	, targetLocked(false)
 	, target(NULL)
 	, lastAttackTime(0)
 {
+	Mob::previousUUID += 1;
 }
 
 void Mob::Init(const Point& pos, bool attackingNorth)


### PR DESCRIPTION
The UUID of mobs is not being incremented when they are created. Because of this, all mobs will have the same UUID and detect themselves as "self," therefore rendering any collision code unused.

This fix makes each mobs UUID 1 + the previous ID (the +1 is technically unnecessary, but seems to align with the intent of the variable). It then increments previous ID by 1 when the mob is created.