### PR TITLE
Fix building bug so they display

### DIFF
--- a/CrashLoyal/src/Building.cpp
+++ b/CrashLoyal/src/Building.cpp
@@ -33,7 +33,7 @@ int Building::attack(int dmg) {
 }
 
 std::shared_ptr<Point> Building::getPosition() {
-	return std::shared_ptr<Point>(&(this->pos));
+	return std::make_shared<Point>(this->pos);
 }
 
 float Building::GetSize() const {
@@ -42,8 +42,11 @@ float Building::GetSize() const {
 
 void Building::attackProcedure(double elapsedTime) {
 	if (this->lastAttackTime >= this->GetAttackTime()) {
-		this->target->attack(this->GetDamage());
-		this->lastAttackTime = 0; // lastAttackTime is incremented in the main update function
+		if (this->target != nullptr) {
+			//this->target->attack(this->GetDamage());
+			this->lastAttackTime = 0; // lastAttackTime is incremented in the main update function
+		}
+		
 		return;
 	}
 }

--- a/CrashLoyal/src/Building.h
+++ b/CrashLoyal/src/Building.h
@@ -44,7 +44,7 @@ public:
 
 	Building(Point p, BuildingType type) : Building(p.x, p.y, type) { }
 
-	bool isDead() { return this->health >= 0; }
+	bool isDead() { return this->health <= 0; }
 
 	int attack(int dmg);
 


### PR DESCRIPTION
Buildings currently do not display, making it difficult to test building collisions. This seems to be because of flipped logic in the building death check.

Fixing this triggers a crash in the building attack code. That line is commented out so that the game will run. Since this line was not triggering anyways, I do not see this PR as breaking functionality.