### PR TITLE
Fix for incorrect UUID incrementation

### DIFF
--- a/CrashLoyal/src/Mob.cpp
+++ b/CrashLoyal/src/Mob.cpp
@@ -16,13 +16,14 @@ Mob::Mob()
 	, nextWaypoint(NULL)
 	, targetPosition(new Point)
 	, state(MobState::Moving)
-	, uuid(Mob::previousUUID)
+	, uuid(Mob::previousUUID + 1)
 	, attackingNorth(true)
 	, health(-1)
 	, targetLocked(false)
 	, target(NULL)
 	, lastAttackTime(0)
 {
+	Mob::previousUUID += 1;
 }
 
 void Mob::Init(const Point& pos, bool attackingNorth)


### PR DESCRIPTION
The UUID of mobs is not being incremented when they are created. Because of this, all mobs will have the same UUID and detect themselves as "self," therefore rendering any collision code unused.
This fix makes each mobs UUID 1 + the previous ID (the +1 is technically unnecessary, but seems to align with the intent of the variable). It then increments previous ID by 1 when the mob is created.